### PR TITLE
Feature/sync status with docusign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ docusign-*.gem
 *.sqlite3
 .byebug_history
 /uploads/
+/spec/railsapp/public/uploads/*

--- a/app/controllers/docusign/response_controller.rb
+++ b/app/controllers/docusign/response_controller.rb
@@ -7,7 +7,7 @@ module Docusign
       @template = "docusign/response/codes/#{@event}"
       @envelope = Docusign::Envelope.find(params[:envelope])
       @signer = Docusign::Signer.find(params[:signer])
-      @envelope.update(status: @event) if @envelope.present?
+      @envelope.sync_status_from_docusign if @envelope.present?
       @signer.update(status: signer_status) if @signer.present?
     end
 

--- a/spec/docusign_spec.rb
+++ b/spec/docusign_spec.rb
@@ -157,6 +157,20 @@ describe Docusign do
       expect(envelope.send(:misc_data)).to eq({ enable_wet_sign: false, random_stuff: 'and things' })
     end
 
+    it 'will update envelope to status other than created or sent' do
+      envelope.save
+      envelope.update!(status: 'completed')
+      expect(envelope.status).to eq('completed')
+    end
+
+    it 'can sync envelope status from docusign' do
+      envelope.save
+      envelope.status = 'voided'
+      expect(envelope.status).to eq('voided')
+      envelope.sync_status_from_docusign
+      expect(envelope.status).to eq('created')
+    end
+
   end
 
   context 'Signer' do

--- a/spec/helpers/document_helper_spec.rb
+++ b/spec/helpers/document_helper_spec.rb
@@ -22,7 +22,7 @@ describe Docusign::DocumentHelper do
     h = [*1000..3000].sample
     iframe = embedded_document(envelope, width: w, height: h)
     expect(iframe).to include("<iframe width=\"#{w}\" height=\"#{h}\"")
-    expect(iframe).to include('https://demo.docusign.net/Signing/startinsession.aspx')
+    expect(iframe).to include('https://demo.docusign.net/Signing/StartInSession.aspx')
   end
 
 end


### PR DESCRIPTION
I ran into some issues updating Envelope statuses to anything other than 'Created' or 'Sent'. Updating to something like 'Signed' is important, so we can track that information in our app that is using this gem.

It seems like it would make sense to align the Envelope model statuses with the statuses documented here: https://www.docusign.com/p/APIGuide/Content/Status%20and%20Managing%20Group/EnvelopeStatus.htm

I also added a method to sync the Envelope status with the status in docusign. This allows you to update the envelope status in `response_controller` to reflect whatever status the envelope is in after that request arrives.

It might make sense to update docusign status after all updates, or something like that, but this variation serves our purposes well enough.

